### PR TITLE
Set variables inside trusted domain script

### DIFF
--- a/vagrant/oc8ce/set-trusted-domain.sh
+++ b/vagrant/oc8ce/set-trusted-domain.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
+IFACE="eth0"
+IFCONFIG="/sbin/ifconfig"
+ADDRESS=$($IFCONFIG $IFACE | awk -F'[: ]+' '/\<inet\>/ {print $4; exit}')
 
 # only set trusted domian once
 # then delete this file in check.init.sh after the script is run to avoid new config every time the VM boots
-php /var/scripts/update-config.php $oc/config/config.php 'trusted_domains[]' localhost ${ADDRESSES[@]} $(hostname) $(hostname --fqdn)
+php /var/scripts/update-config.php $oc/config/config.php 'trusted_domains[]' localhost ${ADDRESS[@]} $(hostname) $(hostname --fqdn)
 php /var/scripts/update-config.php $oc/config/config.php overwrite.cli.url https://$ADDRESS/owncloud


### PR DESCRIPTION
Set Variable inside the script instead. Also changde ADDRESSES --> ADDRESS @jnweiger Why is it called ADDRESSES and not ADDRESS?

Possible fix for #34 
